### PR TITLE
fix(canary): add manual timestamp to canary status

### DIFF
--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -20,12 +20,11 @@ import (
 	"context"
 	"fmt"
 	"github.com/fluxcd/flagger/pkg/utils"
-	"strings"
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"strings"
+	"time"
 
 	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
 	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
@@ -187,9 +186,15 @@ func setStatusPhase(flaggerClient clientset.Interface, cd *flaggerv1.Canary, pha
 		if phase == flaggerv1.CanaryPhaseInitialized || phase == flaggerv1.CanaryPhaseSucceeded {
 			cdCopy.Status.LastPromotedSpec = cd.Status.LastAppliedSpec
 		}
-		// set manual timestamp
+		// reset manual state
 		if phase == flaggerv1.CanaryPhaseSucceeded || phase == flaggerv1.CanaryPhaseFailed {
-			cdCopy.Status.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
+			if cdCopy.Status.ManualState != nil {
+				var weight = 0
+				cdCopy.Status.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
+				cdCopy.Status.ManualState.Paused = false
+				cdCopy.Status.ManualState.Weight = &weight
+				cdCopy.Status.ManualState.Timestamp = ""
+			}
 		}
 
 		if ok, conditions := MakeStatusConditions(cdCopy, phase); ok {

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -19,15 +19,13 @@ package canary
 import (
 	"context"
 	"fmt"
+	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
+	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
 	"github.com/fluxcd/flagger/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"strings"
-	"time"
-
-	flaggerv1 "github.com/fluxcd/flagger/pkg/apis/flagger/v1beta1"
-	clientset "github.com/fluxcd/flagger/pkg/client/clientset/versioned"
 )
 
 func syncCanaryStatus(flaggerClient clientset.Interface, cd *flaggerv1.Canary,
@@ -189,11 +187,7 @@ func setStatusPhase(flaggerClient clientset.Interface, cd *flaggerv1.Canary, pha
 		// reset manual state
 		if phase == flaggerv1.CanaryPhaseSucceeded || phase == flaggerv1.CanaryPhaseFailed {
 			if cdCopy.Status.ManualState != nil {
-				var weight = 0
-				cdCopy.Status.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
-				cdCopy.Status.ManualState.Paused = false
-				cdCopy.Status.ManualState.Weight = &weight
-				cdCopy.Status.ManualState.Timestamp = ""
+				cdCopy.Status.ManualState = &flaggerv1.CanaryManualState{}
 			}
 		}
 

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/fluxcd/flagger/pkg/utils"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -185,6 +186,10 @@ func setStatusPhase(flaggerClient clientset.Interface, cd *flaggerv1.Canary, pha
 		// on promotion set primary spec hash
 		if phase == flaggerv1.CanaryPhaseInitialized || phase == flaggerv1.CanaryPhaseSucceeded {
 			cdCopy.Status.LastPromotedSpec = cd.Status.LastAppliedSpec
+		}
+		// set manual timestamp
+		if phase == flaggerv1.CanaryPhaseSucceeded || phase == flaggerv1.CanaryPhaseFailed {
+			cdCopy.Status.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
 		}
 
 		if ok, conditions := MakeStatusConditions(cdCopy, phase); ok {

--- a/pkg/canary/status.go
+++ b/pkg/canary/status.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"strings"
+	"time"
 )
 
 func syncCanaryStatus(flaggerClient clientset.Interface, cd *flaggerv1.Canary,
@@ -186,6 +187,7 @@ func setStatusPhase(flaggerClient clientset.Interface, cd *flaggerv1.Canary, pha
 		}
 		// reset manual state
 		if phase == flaggerv1.CanaryPhaseSucceeded || phase == flaggerv1.CanaryPhaseFailed {
+			cdCopy.Status.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
 			if cdCopy.Status.ManualState != nil {
 				cdCopy.Status.ManualState = &flaggerv1.CanaryManualState{}
 			}

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -1172,11 +1172,20 @@ func (c *Controller) rollback(canary *flaggerv1.Canary, canaryController canary.
 	}
 
 	// mark canary as failed
-	if err := canaryController.SyncStatus(canary, flaggerv1.CanaryStatus{
+
+	canaryStatus := flaggerv1.CanaryStatus{
 		Phase:                      flaggerv1.CanaryPhaseFailed,
 		CanaryWeight:               0,
 		LastAppliedManualTimestamp: fmt.Sprintf("%d", time.Now().Unix()),
-	}); err != nil {
+	}
+	if canaryPhaseFailed.Status.ManualState != nil {
+		var weight = 0
+		canaryStatus.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
+		canaryStatus.ManualState.Paused = false
+		canaryStatus.ManualState.Weight = &weight
+		canaryStatus.ManualState.Timestamp = ""
+	}
+	if err := canaryController.SyncStatus(canary, canaryStatus); err != nil {
 		c.logCanaryEvent(canary, fmt.Sprintf("Canary Failed. Scaled down %s.%s", canary.Spec.TargetRef.Name, canary.Namespace), zapcore.ErrorLevel)
 		return
 	} else {

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -1172,18 +1172,13 @@ func (c *Controller) rollback(canary *flaggerv1.Canary, canaryController canary.
 	}
 
 	// mark canary as failed
-
 	canaryStatus := flaggerv1.CanaryStatus{
 		Phase:                      flaggerv1.CanaryPhaseFailed,
 		CanaryWeight:               0,
 		LastAppliedManualTimestamp: fmt.Sprintf("%d", time.Now().Unix()),
 	}
 	if canaryPhaseFailed.Status.ManualState != nil {
-		var weight = 0
-		canaryStatus.LastAppliedManualTimestamp = fmt.Sprintf("%d", time.Now().Unix())
-		canaryStatus.ManualState.Paused = false
-		canaryStatus.ManualState.Weight = &weight
-		canaryStatus.ManualState.Timestamp = ""
+		canaryStatus.ManualState = &flaggerv1.CanaryManualState{}
 	}
 	if err := canaryController.SyncStatus(canary, canaryStatus); err != nil {
 		c.logCanaryEvent(canary, fmt.Sprintf("Canary Failed. Scaled down %s.%s", canary.Spec.TargetRef.Name, canary.Namespace), zapcore.ErrorLevel)

--- a/pkg/controller/scheduler.go
+++ b/pkg/controller/scheduler.go
@@ -1172,7 +1172,11 @@ func (c *Controller) rollback(canary *flaggerv1.Canary, canaryController canary.
 	}
 
 	// mark canary as failed
-	if err := canaryController.SyncStatus(canary, flaggerv1.CanaryStatus{Phase: flaggerv1.CanaryPhaseFailed, CanaryWeight: 0}); err != nil {
+	if err := canaryController.SyncStatus(canary, flaggerv1.CanaryStatus{
+		Phase:                      flaggerv1.CanaryPhaseFailed,
+		CanaryWeight:               0,
+		LastAppliedManualTimestamp: fmt.Sprintf("%d", time.Now().Unix()),
+	}); err != nil {
 		c.logCanaryEvent(canary, fmt.Sprintf("Canary Failed. Scaled down %s.%s", canary.Spec.TargetRef.Name, canary.Namespace), zapcore.ErrorLevel)
 		return
 	} else {


### PR DESCRIPTION
- Added time import to status.go for timestamp functionality
- Set manual timestamp when canary phase is succeeded or failed
- Include manual timestamp in SyncStatus call when marking canary as failed
- Store timestamp as Unix time string in LastAppliedManualTimestamp field